### PR TITLE
Limiting reset database to main branch only

### DIFF
--- a/.github/workflows/reset_db.yml
+++ b/.github/workflows/reset_db.yml
@@ -10,6 +10,8 @@ name: Reset Database
 
 on:
   workflow_dispatch:
+    branches:
+      - main
 
 jobs:
   reset:


### PR DESCRIPTION
Setting ability to trigger reset database workflow to just main branch